### PR TITLE
Fix descrypt collisions

### DIFF
--- a/descrypt.md
+++ b/descrypt.md
@@ -2,10 +2,10 @@
 # James M. Hall, 2010 (https://slashdot.org/submission/1381082/Traditional-DES-collision)
 hiH9IOyyrrl4k:cqjmide
 hiH9IOyyrrl4k:ifpqgio
-# @hops_ch
-broken0z4KxMC:0!>',%$
-broken0z4KxMC:5dUD&66
-# @hops_ch
+# @hops
+brokenOz4KxMc:O!>',%$
+brokenOz4KxMc:5dUD&66
+# @hops
 Tycho2izX8zFg:?SaO9L2
 Tycho2izX8zFg:g[k-gRo
 # General cross-check


### PR DESCRIPTION
I made the mistake to publish the "broken" prefixed descrypt collision as image on Twitter instead of using text which lead to translation errors. 
These are the correct and verified solutions. Also removes my deleted Twitter handle.

Closes #34